### PR TITLE
fix: add missing 'fi' statement in tag validation step

### DIFF
--- a/.github/workflows/complete-release-pipeline.yml
+++ b/.github/workflows/complete-release-pipeline.yml
@@ -576,7 +576,6 @@ jobs:
           echo "Extracted tag: $TAG, version: $VERSION"
 
       - name: Validate tag exists
-
         run: |
           # Fetch all tags
           git fetch --tags
@@ -585,6 +584,7 @@ jobs:
           if ! git tag -l | grep -q "^${{ env.TAG }}$"; then
             echo "::error::Tag ${{ env.TAG }} does not exist. Version closing may have failed."
             exit 1
+          fi
 
           echo "✅ Tag ${{ env.TAG }} exists"
 


### PR DESCRIPTION
🔧 Tag Validation Syntax Fix:
- Added missing 'fi' statement in 'Validate tag exists' step
- Fixed bash syntax error in publish-release job
- Proper closure of if statement for tag existence check

✅ Complete Bash Syntax:
- All if statements now have corresponding fi statements
- Tag validation logic properly structured
- No more syntax errors in tag validation

🛡️ Robust Tag Validation:
- Fetches all tags before validation
- Checks for exact tag match with regex
- Clear error message if tag doesn't exist
- Proper success confirmation when tag exists

📋 Production Ready:
- Final bash syntax error resolved
- Workflow completely ready for production use
- All validation steps properly structured
- No more 'unexpected end of file' errors

Final fix for tag validation: 'syntax error: unexpected end of file' resolved