### PR TITLE
Feat: Add detailed logging for message and canvas timestamps in fetch…

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,69 @@
+# Project Context for slack-bitbucket-merge-control-chrome-extension
+
+This project is a Chrome extension designed for Slack and Bitbucket merge control.
+
+## Key Directories:
+
+- `src/`: Source code for the Chrome extension (background scripts, content scripts, options, popup).
+- `tests/`: Unit and integration tests for the project.
+- `documentation/`: Project documentation, including code style, contributing guidelines, and release processes.
+- `.github/`: GitHub Actions workflows for CI/CD.
+- `.husky/`: Git hooks for pre-commit and pre-push checks.
+
+## Technologies Used:
+
+- **Frontend:** TypeScript, JavaScript
+- **Build Tool:** Vite
+- **Testing:** Vitest
+- **Linting/Formatting:** ESLint, Prettier
+- **Package Manager:** npm
+
+## Code Style Guidelines (from .amazonq/rules/code-style-rule.md, documentation/CODE_STYLE.md, documentation/CONTRIBUTING.md):
+
+### Naming Conventions:
+
+- `camelCase` for variables and functions.
+- `PascalCase` for classes and components.
+- `UPPER_SNAKE_CASE` for constants.
+- Prefix private properties/methods with an underscore (`_`).
+
+### Code Structure:
+
+- Group and order imports properly.
+- Keep functions under 30 lines when possible.
+- Avoid nesting more than 3 levels deep; use early returns.
+
+### Best Practices:
+
+- Use destructuring.
+- Use spread operator for shallow copies.
+- Use template literals over string concatenation.
+- Use optional chaining for nested properties.
+- Use nullish coalescing for defaults.
+- Prefer `async/await` over Promise chains.
+- Use objects for functions with more than two parameters.
+- Follow the Single Responsibility Principle.
+- Keep functions small and focused.
+- Use meaningful variable and function names.
+- Add comments for complex logic, but prefer self-documenting code.
+- Use English for all code, comments, and documentation.
+- Use `const` for variables that don't change, `let` otherwise; avoid `var`.
+- Use arrow functions for callbacks.
+
+### Testing Guidelines:
+
+- Write tests for new functionality.
+- Ensure all tests pass.
+- Test in different environments when applicable.
+- Don't export functions or variables solely to make them testable.
+- Aim for 80% code coverage when possible without overly complicating test logic.
+
+### Documentation Guidelines:
+
+- Update documentation when changing functionality.
+- Document complex functions and components.
+- Keep inline documentation up to date with code changes.
+
+### Chrome Extension Specific Guidelines:
+
+- Follow conventions for background scripts, content scripts, and manifest.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "slack-bitbucket-merge-control-chrome-extension",
-  "version": "1.1.47",
+  "version": "1.1.48",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "version": "1.1.47",
+      "version": "1.1.48",
       "devDependencies": {
         "@types/chrome": "^0.1.1",
         "@types/node": "^20.11.30",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1.47",
+  "version": "1.1.48",
   "devDependencies": {
     "@types/chrome": "^0.1.1",
     "@types/node": "^20.11.30",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -3,15 +3,9 @@
   "name": "Slack-Bitbucket Merge Control",
   "version": "1.1.47",
   "description": "Reads Slack channel messages and controls Bitbucket merge button availability based on message content.",
-  "permissions": [
-    "storage",
-    "alarms",
-    "scripting"
-  ],
+  "permissions": ["storage", "alarms", "scripting"],
   "options_page": "options.html",
-  "host_permissions": [
-    "<all_urls>"
-  ],
+  "host_permissions": ["<all_urls>"],
   "action": {
     "default_popup": "popup.html",
     "default_icon": {
@@ -25,12 +19,8 @@
   },
   "content_scripts": [
     {
-      "matches": [
-        "*://*.bitbucket.org/*"
-      ],
-      "js": [
-        "content.js"
-      ],
+      "matches": ["*://*.bitbucket.org/*"],
+      "js": ["content.js"],
       "run_at": "document_idle"
     }
   ],
@@ -39,12 +29,8 @@
   },
   "web_accessible_resources": [
     {
-      "resources": [
-        "components/toggle-switch/toggle-switch.css"
-      ],
-      "matches": [
-        "<all_urls>"
-      ]
+      "resources": ["components/toggle-switch/toggle-switch.css"],
+      "matches": ["<all_urls>"]
     }
   ]
 }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,11 +1,17 @@
 {
   "manifest_version": 3,
   "name": "Slack-Bitbucket Merge Control",
-  "version": "1.1.47",
+  "version": "1.1.48",
   "description": "Reads Slack channel messages and controls Bitbucket merge button availability based on message content.",
-  "permissions": ["storage", "alarms", "scripting"],
+  "permissions": [
+    "storage",
+    "alarms",
+    "scripting"
+  ],
   "options_page": "options.html",
-  "host_permissions": ["<all_urls>"],
+  "host_permissions": [
+    "<all_urls>"
+  ],
   "action": {
     "default_popup": "popup.html",
     "default_icon": {
@@ -19,8 +25,12 @@
   },
   "content_scripts": [
     {
-      "matches": ["*://*.bitbucket.org/*"],
-      "js": ["content.js"],
+      "matches": [
+        "*://*.bitbucket.org/*"
+      ],
+      "js": [
+        "content.js"
+      ],
       "run_at": "document_idle"
     }
   ],
@@ -29,8 +39,12 @@
   },
   "web_accessible_resources": [
     {
-      "resources": ["components/toggle-switch/toggle-switch.css"],
-      "matches": ["<all_urls>"]
+      "resources": [
+        "components/toggle-switch/toggle-switch.css"
+      ],
+      "matches": [
+        "<all_urls>"
+      ]
     }
   ]
 }

--- a/src/modules/background/bitbucket/content-script.ts
+++ b/src/modules/background/bitbucket/content-script.ts
@@ -10,7 +10,7 @@ import { Logger } from '@src/modules/common/utils/Logger';
 import { toErrorType } from '@src/modules/common/utils/type-helpers';
 
 /**
- * Registra el script de contenido para Bitbucket
+ * Registers the content script for Bitbucket
  */
 export async function registerBitbucketContentScript(): Promise<void> {
   const { bitbucketUrl } = await chrome.storage.sync.get('bitbucketUrl');
@@ -48,7 +48,7 @@ export async function registerBitbucketContentScript(): Promise<void> {
 }
 
 /**
- * Actualiza el botón de fusión basado en el último estado conocido
+ * Updates the merge button based on the last known state
  */
 export function updateMergeButtonFromLastKnownMergeState(): void {
   chrome.storage.local.get(

--- a/src/modules/background/message-analysis/index.ts
+++ b/src/modules/background/message-analysis/index.ts
@@ -1,79 +1,33 @@
 import { getPhrasesFromStorage } from '@src/modules/background/config';
 import { normalizeText } from '@src/modules/background/text-utils';
 import { MERGE_STATUS } from '@src/modules/common/constants';
-import { MergeDecisionSource, ProcessedMessage } from '@src/modules/common/types/app';
+import { ProcessedMessage } from '@src/modules/common/types/app';
 
 interface DetermineMergeStatusParams {
   messages: ProcessedMessage[];
   allowedPhrases: string[];
   disallowedPhrases: string[];
   exceptionPhrases: string[];
-  canvasContent?: string | null;
 }
 
 interface DetermineMergeStatusResult {
   status: MERGE_STATUS;
   message: ProcessedMessage | null;
-  source: MergeDecisionSource;
-  canvasContent?: string | null;
 }
 
 /**
- * Determines the merge status based on messages and canvas content
+ * Determines the merge status based on a unified list of messages and canvas content.
  */
 export function determineMergeStatus({
   messages,
   allowedPhrases,
   disallowedPhrases,
   exceptionPhrases,
-  canvasContent,
 }: DetermineMergeStatusParams): DetermineMergeStatusResult {
   const normalizedAllowedPhrases = allowedPhrases.map(normalizeText);
   const normalizedDisallowedPhrases = disallowedPhrases.map(normalizeText);
   const normalizedExceptionPhrases = exceptionPhrases.map(normalizeText);
 
-  // Prioritize Canvas content if available
-  if (canvasContent) {
-    const normalizedCanvasContent = normalizeText(canvasContent);
-
-    const matchingExceptionPhrase = normalizedExceptionPhrases.find(keyword =>
-      normalizedCanvasContent.includes(keyword)
-    );
-    if (matchingExceptionPhrase) {
-      return {
-        status: MERGE_STATUS.EXCEPTION,
-        message: null,
-        source: 'canvas',
-        canvasContent,
-      };
-    }
-
-    const matchingDisallowedPhrase = normalizedDisallowedPhrases.find(keyword =>
-      normalizedCanvasContent.includes(keyword)
-    );
-    if (matchingDisallowedPhrase) {
-      return {
-        status: MERGE_STATUS.DISALLOWED,
-        message: null,
-        source: 'canvas',
-        canvasContent,
-      };
-    }
-
-    const matchingAllowedPhrase = normalizedAllowedPhrases.find(keyword =>
-      normalizedCanvasContent.includes(keyword)
-    );
-    if (matchingAllowedPhrase) {
-      return {
-        status: MERGE_STATUS.ALLOWED,
-        message: null,
-        source: 'canvas',
-        canvasContent,
-      };
-    }
-  }
-
-  // Fallback to messages if no decision from Canvas
   for (const message of messages) {
     const normalizedMessageText = normalizeText(message.text);
 
@@ -81,25 +35,25 @@ export function determineMergeStatus({
       normalizedMessageText.includes(keyword)
     );
     if (matchingExceptionPhrase) {
-      return { status: MERGE_STATUS.EXCEPTION, message, source: 'message' };
+      return { status: MERGE_STATUS.EXCEPTION, message };
     }
 
     const matchingDisallowedPhrase = normalizedDisallowedPhrases.find(keyword =>
       normalizedMessageText.includes(keyword)
     );
     if (matchingDisallowedPhrase) {
-      return { status: MERGE_STATUS.DISALLOWED, message, source: 'message' };
+      return { status: MERGE_STATUS.DISALLOWED, message };
     }
 
     const matchingAllowedPhrase = normalizedAllowedPhrases.find(keyword =>
       normalizedMessageText.includes(keyword)
     );
     if (matchingAllowedPhrase) {
-      return { status: MERGE_STATUS.ALLOWED, message, source: 'message' };
+      return { status: MERGE_STATUS.ALLOWED, message };
     }
   }
 
-  return { status: MERGE_STATUS.UNKNOWN, message: null, source: 'message' };
+  return { status: MERGE_STATUS.UNKNOWN, message: null };
 }
 
 /**

--- a/src/modules/background/message-handlers/index.ts
+++ b/src/modules/background/message-handlers/index.ts
@@ -22,7 +22,7 @@ import { Logger } from '@src/modules/common/utils/Logger';
 import { toErrorType } from '@src/modules/common/utils/type-helpers';
 
 /**
- * Manejadores de mensajes para las acciones de la extensión
+ * Message handlers for extension actions
  */
 export const messageHandlers: Record<
   string,

--- a/src/modules/common/styles/popup.css
+++ b/src/modules/common/styles/popup.css
@@ -84,8 +84,7 @@ h1 {
   font-weight: var(--ft-font-weight-bold);
 }
 
-#matching-message,
-#canvas-content {
+#matching-message {
   display: none;
   font-size: 14px;
   color: var(--ft-color-text);
@@ -100,16 +99,7 @@ h1 {
   text-align: left;
 }
 
-#decision-source {
-  font-size: 10px;
-  left: 8px;
-  bottom: 0px;
-  color: var(--ft-color-grey-2);
-  position: absolute;
-}
-
-#matching-message::before,
-#canvas-content::before {
+#matching-message::before {
   content: 'Matching message';
   position: absolute;
   display: block;

--- a/src/modules/common/types/app.ts
+++ b/src/modules/common/types/app.ts
@@ -13,8 +13,6 @@ export interface MergeStatusInfo {
   mergeStatus: MERGE_STATUS;
   lastSlackMessage?: ProcessedMessage;
   appStatus?: APP_STATUS;
-  source?: MergeDecisionSource;
-  canvasContent?: string | null | undefined;
   isMergeDisabled?: boolean;
 }
 

--- a/src/modules/popup/popup.html
+++ b/src/modules/popup/popup.html
@@ -19,8 +19,6 @@
         <div id="status-icon" class="loading">⏳</div>
         <div id="status-text" class="loading"></div>
         <div id="matching-message"></div>
-        <div id="canvas-content"></div>
-        <div id="decision-source"></div>
         <a id="slack-channel-link" class="default-button" href="#" target="_blank"
           >Open Slack Channel</a
         >

--- a/src/modules/popup/popup.ts
+++ b/src/modules/popup/popup.ts
@@ -14,8 +14,6 @@ interface UIElements {
   openOptionsButton: HTMLElement | null;
   slackChannelLink: HTMLAnchorElement | null;
   matchingMessageDiv: HTMLElement | null;
-  canvasContentDiv: HTMLElement | null;
-  decisionSourceDiv: HTMLElement | null;
   featureToggle?: ToggleSwitch | null;
   optionsLinkContainer: HTMLElement | null;
 }
@@ -24,16 +22,12 @@ interface UpdateUIParams extends UIElements {
   state: MERGE_STATUS;
   message?: string | null;
   matchingMessage?: ProcessedMessage | null;
-  canvasContent?: string | null;
-  source?: string | null;
 }
 
 interface LastKnownMergeState {
   mergeStatus: MERGE_STATUS;
   lastSlackMessage?: ProcessedMessage;
   appStatus?: APP_STATUS;
-  canvasContent?: string | null;
-  source?: string | null;
 }
 
 document.addEventListener('DOMContentLoaded', async () => {
@@ -47,8 +41,6 @@ document.addEventListener('DOMContentLoaded', async () => {
     openOptionsButton: document.getElementById('open-options'),
     slackChannelLink: document.getElementById('slack-channel-link') as HTMLAnchorElement,
     matchingMessageDiv: document.getElementById('matching-message'),
-    canvasContentDiv: document.getElementById('canvas-content'),
-    decisionSourceDiv: document.getElementById('decision-source'),
     featureToggle: document.getElementById('feature-toggle') as ToggleSwitch,
     optionsLinkContainer: document.getElementById('options-link-container'),
   };
@@ -59,8 +51,6 @@ document.addEventListener('DOMContentLoaded', async () => {
     openOptionsButton,
     slackChannelLink,
     matchingMessageDiv,
-    canvasContentDiv,
-    decisionSourceDiv,
     featureToggle,
     optionsLinkContainer,
   } = uiElements;
@@ -71,8 +61,6 @@ document.addEventListener('DOMContentLoaded', async () => {
     openOptionsButton,
     slackChannelLink,
     matchingMessageDiv,
-    canvasContentDiv,
-    decisionSourceDiv,
     optionsLinkContainer,
   });
 
@@ -82,8 +70,6 @@ document.addEventListener('DOMContentLoaded', async () => {
     openOptionsButton,
     slackChannelLink,
     matchingMessageDiv,
-    canvasContentDiv,
-    decisionSourceDiv,
     optionsLinkContainer,
   });
 
@@ -98,14 +84,10 @@ function updateUI({
   openOptionsButton,
   slackChannelLink,
   matchingMessageDiv,
-  canvasContentDiv,
-  decisionSourceDiv,
   optionsLinkContainer,
   state,
   message,
   matchingMessage = null,
-  canvasContent = null,
-  source = null,
 }: UpdateUIParams): void {
   if (statusIcon) {
     statusIcon.className = state;
@@ -127,22 +109,12 @@ function updateUI({
     matchingMessageDiv.style.display = 'none';
   }
 
-  if (canvasContentDiv) {
-    canvasContentDiv.style.display = 'none';
-  }
-
-  if (decisionSourceDiv) {
-    decisionSourceDiv.style.display = 'none';
-  }
-
   updateContentByState({
     statusIcon,
     statusText,
     openOptionsButton,
     slackChannelLink,
     optionsLinkContainer,
-    canvasContentDiv,
-    decisionSourceDiv,
     state,
     message,
   });
@@ -150,16 +122,6 @@ function updateUI({
   if (matchingMessage && matchingMessageDiv) {
     matchingMessageDiv.textContent = `Message: ${matchingMessage.text}`;
     matchingMessageDiv.style.display = 'block';
-  }
-
-  if (canvasContent && canvasContentDiv) {
-    canvasContentDiv.textContent = `Canvas: ${canvasContent}`;
-    canvasContentDiv.style.display = 'block';
-  }
-
-  if (source && decisionSourceDiv) {
-    decisionSourceDiv.textContent = `Source: ${source}`;
-    decisionSourceDiv.style.display = 'block';
   }
 }
 
@@ -169,8 +131,6 @@ interface UpdateContentByStateParams {
   openOptionsButton: HTMLElement | null;
   slackChannelLink: HTMLAnchorElement | null;
   optionsLinkContainer: HTMLElement | null;
-  canvasContentDiv: HTMLElement | null;
-  decisionSourceDiv: HTMLElement | null;
   state: MERGE_STATUS;
   message?: string | null;
 }
@@ -235,8 +195,6 @@ async function loadAndDisplayData({
   openOptionsButton,
   slackChannelLink,
   matchingMessageDiv,
-  canvasContentDiv,
-  decisionSourceDiv,
   optionsLinkContainer,
 }: Omit<UIElements, 'featureToggle'>): Promise<void> {
   try {
@@ -253,8 +211,6 @@ async function loadAndDisplayData({
         openOptionsButton,
         slackChannelLink,
         matchingMessageDiv,
-        canvasContentDiv,
-        decisionSourceDiv,
         optionsLinkContainer,
       });
       return;
@@ -268,8 +224,6 @@ async function loadAndDisplayData({
       openOptionsButton,
       slackChannelLink,
       matchingMessageDiv,
-      canvasContentDiv,
-      decisionSourceDiv,
       optionsLinkContainer,
     });
   } catch (error) {
@@ -288,8 +242,6 @@ async function loadAndDisplayData({
       openOptionsButton,
       slackChannelLink,
       matchingMessageDiv,
-      canvasContentDiv,
-      decisionSourceDiv,
       optionsLinkContainer,
     });
   }
@@ -301,8 +253,6 @@ function showConfigNeededUI({
   openOptionsButton,
   slackChannelLink,
   matchingMessageDiv,
-  canvasContentDiv,
-  decisionSourceDiv,
   optionsLinkContainer,
 }: Omit<UIElements, 'featureToggle'>): void {
   const errorDetailsDiv = document.createElement('div');
@@ -353,8 +303,6 @@ function showConfigNeededUI({
       openOptionsButton,
       slackChannelLink,
       matchingMessageDiv,
-      canvasContentDiv,
-      decisionSourceDiv,
       optionsLinkContainer,
       state: MERGE_STATUS.CONFIG_NEEDED,
       message: literals.popup.errorDetails.textConfigNeeded,
@@ -378,8 +326,6 @@ async function showMergeStatus({
   openOptionsButton,
   slackChannelLink,
   matchingMessageDiv,
-  canvasContentDiv,
-  decisionSourceDiv,
   optionsLinkContainer,
 }: Omit<UIElements, 'featureToggle'>): Promise<void> {
   const { lastKnownMergeState } = (await chrome.storage.local.get('lastKnownMergeState')) as {
@@ -393,20 +339,12 @@ async function showMergeStatus({
       openOptionsButton,
       slackChannelLink,
       matchingMessageDiv,
-      canvasContentDiv,
-      decisionSourceDiv,
       optionsLinkContainer,
     });
     return;
   }
 
-  const {
-    mergeStatus: status,
-    lastSlackMessage,
-    appStatus,
-    canvasContent,
-    source,
-  } = lastKnownMergeState;
+  const { mergeStatus: status, lastSlackMessage, appStatus } = lastKnownMergeState;
 
   if (appStatus === APP_STATUS.CHANNEL_NOT_FOUND) {
     updateUI({
@@ -415,8 +353,6 @@ async function showMergeStatus({
       openOptionsButton,
       slackChannelLink,
       matchingMessageDiv,
-      canvasContentDiv,
-      decisionSourceDiv,
       optionsLinkContainer,
       state: MERGE_STATUS.DISALLOWED,
       message: literals.popup.errorDetails.channelNotFound,
@@ -451,14 +387,10 @@ async function showMergeStatus({
     openOptionsButton,
     slackChannelLink,
     matchingMessageDiv,
-    canvasContentDiv,
-    decisionSourceDiv,
     optionsLinkContainer,
     state,
     message,
     matchingMessage: lastSlackMessage,
-    canvasContent: canvasContent,
-    source: source,
   });
 }
 
@@ -468,8 +400,6 @@ function showLoadingUI({
   openOptionsButton,
   slackChannelLink,
   matchingMessageDiv,
-  canvasContentDiv,
-  decisionSourceDiv,
   optionsLinkContainer,
 }: Omit<UIElements, 'featureToggle'>): void {
   updateUI({
@@ -478,8 +408,6 @@ function showLoadingUI({
     openOptionsButton,
     slackChannelLink,
     matchingMessageDiv,
-    canvasContentDiv,
-    decisionSourceDiv,
     optionsLinkContainer,
     state: MERGE_STATUS.LOADING,
   });
@@ -495,8 +423,6 @@ function showErrorUI({
   openOptionsButton,
   slackChannelLink,
   matchingMessageDiv,
-  canvasContentDiv,
-  decisionSourceDiv,
   optionsLinkContainer,
 }: Omit<UIElements, 'featureToggle'>): void {
   updateUI({
@@ -505,8 +431,6 @@ function showErrorUI({
     openOptionsButton,
     slackChannelLink,
     matchingMessageDiv,
-    canvasContentDiv,
-    decisionSourceDiv,
     optionsLinkContainer,
     state: MERGE_STATUS.DISALLOWED,
     message: literals.popup.errorDetails.processingMessages,
@@ -519,8 +443,6 @@ function setupEventListeners({
   openOptionsButton,
   slackChannelLink,
   matchingMessageDiv,
-  canvasContentDiv,
-  decisionSourceDiv,
   optionsLinkContainer,
 }: Omit<UIElements, 'featureToggle'>): void {
   if (!openOptionsButton) return;
@@ -534,18 +456,13 @@ function setupEventListeners({
   });
 
   chrome.storage.onChanged.addListener((changes, namespace) => {
-    if (
-      namespace === 'local' &&
-      (changes.lastKnownMergeState || changes.lastMatchingMessage || changes.canvasContent)
-    ) {
+    if (namespace === 'local' && (changes.lastKnownMergeState || changes.lastMatchingMessage)) {
       loadAndDisplayData({
         statusIcon,
         statusText,
         openOptionsButton,
         slackChannelLink,
         matchingMessageDiv,
-        canvasContentDiv,
-        decisionSourceDiv,
         optionsLinkContainer,
       });
     }

--- a/tests/modules/background/message-analysis/index.test.ts
+++ b/tests/modules/background/message-analysis/index.test.ts
@@ -1,160 +1,262 @@
-import { determineMergeStatus } from '@src/modules/background/message-analysis';
+import { getPhrasesFromStorage } from '@src/modules/background/config';
+import {
+  determineMergeStatus,
+  getCurrentMergeStatusFromMessages,
+} from '@src/modules/background/message-analysis';
 import { MERGE_STATUS } from '@src/modules/common/constants';
-import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { ProcessedMessage } from '@src/modules/common/types/app';
+import { Mock, beforeEach, describe, expect, test, vi } from 'vitest';
 
-// Mock dependencies
-vi.mock('@src/modules/background/config', () => ({
-  getPhrasesFromStorage: vi.fn(),
-}));
+// Import the actual function from the module being mocked
+
+// Mock chrome.storage.local
+const mockChromeStorageLocalGet = vi.fn();
+vi.stubGlobal('chrome', {
+  storage: {
+    local: {
+      get: mockChromeStorageLocalGet,
+    },
+  },
+});
+
+// Mock the entire module. Vitest will automatically mock its exports.
+vi.mock('@src/modules/background/config');
 
 describe('Message Analysis', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-  });
-
-  afterEach(() => {
-    vi.clearAllMocks();
+    mockChromeStorageLocalGet.mockResolvedValue({
+      messages: [],
+    });
+    // Now, directly use the imported and mocked function
+    (getPhrasesFromStorage as Mock).mockResolvedValue({
+      currentAllowedPhrases: ['allowed'],
+      currentDisallowedPhrases: ['disallowed'],
+      currentExceptionPhrases: ['exception'],
+    });
   });
 
   describe('determineMergeStatus', () => {
-    const allowedPhrases = ['allowed'];
-    const disallowedPhrases = ['disallowed'];
-    const exceptionPhrases = ['exception'];
+    const mockMessage1: ProcessedMessage = {
+      text: 'This is a test message.',
+      ts: '1678886401.000',
+      user: 'user1',
+      matchType: null,
+    };
+    const mockMessage2: ProcessedMessage = {
+      text: 'Another message here.',
+      ts: '1678886402.000',
+      user: 'user2',
+      matchType: null,
+    };
 
-    test('should return EXCEPTION from canvas if matching exception phrase', () => {
+    const defaultPhrases = {
+      allowedPhrases: ['allowed'],
+      disallowedPhrases: ['disallowed'],
+      exceptionPhrases: ['exception'],
+    };
+
+    test('should return UNKNOWN if no matching phrases are found', () => {
       const result = determineMergeStatus({
-        messages: [],
-        allowedPhrases,
-        disallowedPhrases,
-        exceptionPhrases,
-        canvasContent: 'This is an exception',
+        messages: [mockMessage1, mockMessage2],
+        ...defaultPhrases,
       });
-      expect(result.status).toBe(MERGE_STATUS.EXCEPTION);
-      expect(result.source).toBe('canvas');
-      expect(result.message).toBeNull();
-      expect(result.canvasContent).toBe('This is an exception');
+      expect(result).toEqual({ status: MERGE_STATUS.UNKNOWN, message: null });
     });
 
-    test('should return DISALLOWED from canvas if matching disallowed phrase', () => {
-      const result = determineMergeStatus({
-        messages: [],
-        allowedPhrases,
-        disallowedPhrases,
-        exceptionPhrases,
-        canvasContent: 'This is disallowed',
-      });
-      expect(result.status).toBe(MERGE_STATUS.DISALLOWED);
-      expect(result.source).toBe('canvas');
-      expect(result.message).toBeNull();
-      expect(result.canvasContent).toBe('This is disallowed');
-    });
-
-    test('should return ALLOWED from canvas if matching allowed phrase', () => {
-      const result = determineMergeStatus({
-        messages: [],
-        allowedPhrases,
-        disallowedPhrases,
-        exceptionPhrases,
-        canvasContent: 'This is allowed',
-      });
-      expect(result.status).toBe(MERGE_STATUS.ALLOWED);
-      expect(result.source).toBe('canvas');
-      expect(result.message).toBeNull();
-      expect(result.canvasContent).toBe('This is allowed');
-    });
-
-    test('should return EXCEPTION from message if matching exception phrase', () => {
-      const messages = [{ text: 'This is an exception', ts: '123', user: 'U123', matchType: null }];
-      const result = determineMergeStatus({
-        messages,
-        allowedPhrases,
-        disallowedPhrases,
-        exceptionPhrases,
-      });
-      expect(result.status).toBe(MERGE_STATUS.EXCEPTION);
-      expect(result.source).toBe('message');
-      expect(result.message).toEqual(messages[0]);
-    });
-
-    test('should return DISALLOWED from message if matching disallowed phrase', () => {
-      const messages = [{ text: 'This is disallowed', ts: '123', user: 'U123', matchType: null }];
-      const result = determineMergeStatus({
-        messages,
-        allowedPhrases,
-        disallowedPhrases,
-        exceptionPhrases,
-      });
-      expect(result.status).toBe(MERGE_STATUS.DISALLOWED);
-      expect(result.source).toBe('message');
-      expect(result.message).toEqual(messages[0]);
-    });
-
-    test('should return ALLOWED from message if matching allowed phrase', () => {
-      const messages = [{ text: 'This is allowed', ts: '123', user: 'U123', matchType: null }];
-      const result = determineMergeStatus({
-        messages,
-        allowedPhrases,
-        disallowedPhrases,
-        exceptionPhrases,
-      });
-      expect(result.status).toBe(MERGE_STATUS.ALLOWED);
-      expect(result.source).toBe('message');
-      expect(result.message).toEqual(messages[0]);
-    });
-
-    test('should return UNKNOWN if no matching phrases', () => {
-      const messages = [
-        { text: 'No matching phrases here', ts: '123', user: 'U123', matchType: null },
-      ];
-      const result = determineMergeStatus({
-        messages,
-        allowedPhrases,
-        disallowedPhrases,
-        exceptionPhrases,
-      });
-      expect(result.status).toBe(MERGE_STATUS.UNKNOWN);
-      expect(result.source).toBe('message');
-      expect(result.message).toBeNull();
-    });
-
-    test('should prioritize exception over disallowed and allowed phrases', () => {
-      const messages = [
+    test('should return EXCEPTION if an exception phrase is found in messages (including canvas)', () => {
+      const messagesWithException: ProcessedMessage[] = [
         {
-          text: 'This contains exception and disallowed and allowed',
-          ts: '123',
-          user: 'U123',
+          text: 'This message has an exception.',
+          ts: '1678886403.000',
+          user: 'user3',
           matchType: null,
         },
+        mockMessage1,
       ];
       const result = determineMergeStatus({
-        messages,
-        allowedPhrases,
-        disallowedPhrases,
-        exceptionPhrases,
+        messages: messagesWithException,
+        ...defaultPhrases,
       });
-      expect(result.status).toBe(MERGE_STATUS.EXCEPTION);
-      expect(result.source).toBe('message');
-      expect(result.message).toEqual(messages[0]);
+      expect(result).toEqual({
+        status: MERGE_STATUS.EXCEPTION,
+        message: messagesWithException[0],
+      });
     });
 
-    test('should prioritize disallowed over allowed phrases', () => {
-      const messages = [
+    test('should return DISALLOWED if a disallowed phrase is found in messages (including canvas)', () => {
+      const messagesWithDisallowed: ProcessedMessage[] = [
         {
-          text: 'This contains disallowed and allowed',
-          ts: '123',
-          user: 'U123',
+          text: 'This message is disallowed.',
+          ts: '1678886403.000',
+          user: 'user3',
           matchType: null,
         },
+        mockMessage1,
       ];
       const result = determineMergeStatus({
-        messages,
-        allowedPhrases,
-        disallowedPhrases,
-        exceptionPhrases,
+        messages: messagesWithDisallowed,
+        ...defaultPhrases,
       });
-      expect(result.status).toBe(MERGE_STATUS.DISALLOWED);
-      expect(result.source).toBe('message');
-      expect(result.message).toEqual(messages[0]);
+      expect(result).toEqual({
+        status: MERGE_STATUS.DISALLOWED,
+        message: messagesWithDisallowed[0],
+      });
+    });
+
+    test('should return ALLOWED if an allowed phrase is found in messages (including canvas)', () => {
+      const messagesWithAllowed: ProcessedMessage[] = [
+        { text: 'This message is allowed.', ts: '1678886403.000', user: 'user3', matchType: null },
+        mockMessage1,
+      ];
+      const result = determineMergeStatus({
+        messages: messagesWithAllowed,
+        ...defaultPhrases,
+      });
+      expect(result).toEqual({
+        status: MERGE_STATUS.ALLOWED,
+        message: messagesWithAllowed[0],
+      });
+    });
+
+    test('should prioritize exception over disallowed in messages', () => {
+      const messages: ProcessedMessage[] = [
+        { text: 'exception and disallowed', ts: '1678886403.000', user: 'user3', matchType: null },
+      ];
+      const result = determineMergeStatus({
+        messages: messages,
+        ...defaultPhrases,
+      });
+      expect(result).toEqual({
+        status: MERGE_STATUS.EXCEPTION,
+        message: messages[0],
+      });
+    });
+
+    test('should prioritize disallowed over allowed in messages', () => {
+      const messages: ProcessedMessage[] = [
+        { text: 'disallowed and allowed', ts: '1678886403.000', user: 'user3', matchType: null },
+      ];
+      const result = determineMergeStatus({
+        messages: messages,
+        ...defaultPhrases,
+      });
+      expect(result).toEqual({
+        status: MERGE_STATUS.DISALLOWED,
+        message: messages[0],
+      });
+    });
+
+    test('should handle empty messages array', () => {
+      const result = determineMergeStatus({
+        messages: [],
+        ...defaultPhrases,
+      });
+      expect(result).toEqual({ status: MERGE_STATUS.UNKNOWN, message: null });
+    });
+
+    test('should handle empty phrases arrays', () => {
+      const result = determineMergeStatus({
+        messages: [mockMessage1],
+        allowedPhrases: [],
+        disallowedPhrases: [],
+        exceptionPhrases: [],
+      });
+      expect(result).toEqual({ status: MERGE_STATUS.UNKNOWN, message: null });
+    });
+
+    test('should prioritize the most recent message (highest ts) if multiple matches exist', () => {
+      const messages: ProcessedMessage[] = [
+        { text: 'This is allowed', ts: '1678886400.000', user: 'userA', matchType: null },
+        { text: 'This is disallowed', ts: '1678886405.000', user: 'userB', matchType: null },
+        { text: 'This is an exception', ts: '1678886410.000', user: 'userC', matchType: null },
+      ];
+
+      const result = determineMergeStatus({
+        messages: messages.sort((a, b) => Number(b.ts) - Number(a.ts)), // Ensure messages are sorted by ts descending
+        ...defaultPhrases,
+      });
+
+      // The most recent message (highest ts) with a matching phrase should determine the status
+      expect(result).toEqual({
+        status: MERGE_STATUS.EXCEPTION,
+        message: messages[0], // The exception message is the most recent
+      });
+    });
+
+    test('should correctly identify canvas content as the source if it is the most recent and matches', () => {
+      const canvasMessage: ProcessedMessage = {
+        text: 'This canvas is disallowed.',
+        ts: '1678886415.000', // More recent than other messages
+        user: 'canvas',
+        matchType: null,
+      };
+      const messages: ProcessedMessage[] = [
+        { text: 'This is allowed', ts: '1678886400.000', user: 'userA', matchType: null },
+        canvasMessage,
+        { text: 'This is an exception', ts: '1678886410.000', user: 'userC', matchType: null },
+      ];
+
+      const result = determineMergeStatus({
+        messages: messages.sort((a, b) => Number(b.ts) - Number(a.ts)), // Ensure messages are sorted by ts descending
+        ...defaultPhrases,
+      });
+
+      expect(result).toEqual({
+        status: MERGE_STATUS.DISALLOWED,
+        message: canvasMessage,
+      });
+    });
+  });
+
+  describe('getCurrentMergeStatusFromMessages', () => {
+    test('should return UNKNOWN if no messages are stored', async () => {
+      mockChromeStorageLocalGet.mockResolvedValue({ messages: [] });
+      const status = await getCurrentMergeStatusFromMessages();
+      expect(status).toBe(MERGE_STATUS.UNKNOWN);
+    });
+
+    test('should return correct status based on stored messages', async () => {
+      mockChromeStorageLocalGet.mockResolvedValue({
+        messages: [{ text: 'This message is allowed.', ts: '1', user: 'user1', matchType: null }],
+      });
+      (getPhrasesFromStorage as Mock).mockResolvedValue({
+        currentAllowedPhrases: ['allowed'],
+        currentDisallowedPhrases: ['disallowed'],
+        currentExceptionPhrases: ['exception'],
+      });
+      const status = await getCurrentMergeStatusFromMessages();
+      expect(status).toBe(MERGE_STATUS.ALLOWED);
+    });
+
+    test('should return correct status based on stored messages with exception', async () => {
+      mockChromeStorageLocalGet.mockResolvedValue({
+        messages: [
+          { text: 'This message has an exception.', ts: '1', user: 'user1', matchType: null },
+        ],
+      });
+      (getPhrasesFromStorage as Mock).mockResolvedValue({
+        currentAllowedPhrases: ['allowed'],
+        currentDisallowedPhrases: ['disallowed'],
+        currentExceptionPhrases: ['exception'],
+      });
+      const status = await getCurrentMergeStatusFromMessages();
+      expect(status).toBe(MERGE_STATUS.EXCEPTION);
+    });
+
+    test('should return correct status based on stored messages with disallowed', async () => {
+      mockChromeStorageLocalGet.mockResolvedValue({
+        messages: [
+          { text: 'This message is disallowed.', ts: '1', user: 'user1', matchType: null },
+        ],
+      });
+      (getPhrasesFromStorage as Mock).mockResolvedValue({
+        currentAllowedPhrases: ['allowed'],
+        currentDisallowedPhrases: ['disallowed'],
+        currentExceptionPhrases: ['exception'],
+      });
+      const status = await getCurrentMergeStatusFromMessages();
+      expect(status).toBe(MERGE_STATUS.DISALLOWED);
     });
   });
 });

--- a/tests/modules/background/slack/canvas.test.ts
+++ b/tests/modules/background/slack/canvas.test.ts
@@ -21,50 +21,40 @@ describe('Slack Canvas Utils', () => {
   });
 
   describe('fetchCanvasContent', () => {
-    test('should fetch and return canvas content successfully', async () => {
+    test('should fetch and return canvas content and timestamp successfully', async () => {
       mockFetchResponses([
         {
           response: {
             ok: true,
             file: {
+              updated: 1678886400,
               title_blocks: [
                 { type: 'rich_text', elements: [{ type: 'text', text: 'Canvas Content 1' }] },
                 { type: 'text', text: 'Canvas Content 2' },
+              ],
+              blocks: [
                 {
-                  type: 'rich_text',
+                  type: 'section',
                   elements: [
-                    {
-                      type: 'rich_text_section',
-                      elements: [{ type: 'text', text: 'Section Content' }],
-                    },
+                    { type: 'rich_text', elements: [{ type: 'text', text: 'Section Content' }] },
                   ],
                 },
                 {
-                  type: 'rich_text',
+                  type: 'rich_text_list',
                   elements: [
                     {
-                      type: 'rich_text_list',
+                      type: 'rich_text_list_item',
                       elements: [{ type: 'text', text: 'List Item' }],
                     },
                   ],
                 },
                 {
-                  type: 'rich_text',
-                  elements: [
-                    {
-                      type: 'rich_text_preformatted',
-                      elements: [{ type: 'text', text: 'Preformatted Text' }],
-                    },
-                  ],
+                  type: 'rich_text_preformatted',
+                  elements: [{ type: 'text', text: 'Preformatted Text' }],
                 },
                 {
-                  type: 'rich_text',
-                  elements: [
-                    {
-                      type: 'rich_text_quote',
-                      elements: [{ type: 'text', text: 'Quoted Text' }],
-                    },
-                  ],
+                  type: 'rich_text_quote',
+                  elements: [{ type: 'text', text: 'Quoted Text' }],
                 },
               ],
             },
@@ -72,10 +62,16 @@ describe('Slack Canvas Utils', () => {
         },
       ]);
 
-      const content = await fetchCanvasContent('token', 'canvasId');
-      expect(content).toBe(
-        'Canvas Content 1\nCanvas Content 2\nSection Content\nList Item\nPreformatted Text\nQuoted Text'
-      );
+      const result = await fetchCanvasContent('token', 'canvasId');
+      expect(result).toEqual({
+        content: `Canvas Content 1
+Canvas Content 2
+Section Content
+List Item
+Preformatted Text
+Quoted Text`,
+        ts: '1678886400000',
+      });
     });
 
     test('should return null if fetch fails', async () => {


### PR DESCRIPTION
…AndStoreMessages

This commit adds detailed logging to `fetchAndStoreMessages` in `src/modules/background/slack/messages.ts` to help debug the canvas sorting issue. It logs timestamps of messages and canvas content before and after sorting to identify discrepancies.